### PR TITLE
Fix Line-item Bug in Order Model

### DIFF
--- a/app/models/order.js
+++ b/app/models/order.js
@@ -11,7 +11,10 @@ const orderSchema = new mongoose.Schema({
     // Add validation for possible value set
   },
   // TODO fix lineitem array, crashes server
-  // line_item: [LineItem],
+  line_item: [{
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'LineItem'
+  }],
   owner: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',

--- a/scripts/orders/update.sh
+++ b/scripts/orders/update.sh
@@ -10,7 +10,8 @@ curl "${API}${URL_PATH}/${ID}" \
 --header "Authorization: Bearer ${TOKEN}" \
 --data '{
   "order": {
-    "status": "'"${STATUS}"'"
+    "status": "'"${STATUS}"'",
+    "line_item": "'"${LINEITEM}"'"
   }
 }'
 


### PR DESCRIPTION
-Re-write line_item reference from an array containing LineItem
 `[LineItem]` to an array that contains instances of LineItem.

- Successfully use a curl script to add a line item/product to an order
  (the line item existed in an array) within the order.